### PR TITLE
pin dependencies in fuzz harness

### DIFF
--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -485,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "gio"
-version = "0.15.11"
+version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f132be35e05d9662b9fa0fee3f349c6621f7782e0105917f4cc73c1bf47eceb"
+checksum = "68fdbc90312d462781a395f7a16d96a2b379bb6ef8cd6310a2df272771c4283b"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.15.11"
+version = "0.15.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd124026a2fa8c33a3d17a3fe59c103f2d9fa5bd92c19e029e037736729abeab"
+checksum = "edb0306fbad0ab5428b0ca674a23893db909a98582969c9b537be4ced78c505d"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "librsvg"
-version = "2.54.3"
+version = "2.55.0"
 dependencies = [
  "byteorder",
  "cairo-rs",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,8 +10,8 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-glib = "0.15"
-gio = { version="0.15", features=["v2_50"] }
+glib = { version = "0.15.12", features = ["v2_50"] }
+gio = { version = "0.15.12", features = ["v2_50"] }
 
 [dependencies.librsvg]
 path = ".."


### PR DESCRIPTION
previously the fuzz harness specified dependencies with the same specificity as the parent library, but somewhere a crate is not following semver as cargo assumes. Pinning to a specific version of glib fixes the build